### PR TITLE
Display business closure status/details from the Reservoir Coffee web API

### DIFF
--- a/api/business_hours.sql
+++ b/api/business_hours.sql
@@ -1,9 +1,10 @@
 CREATE TABLE public.business_hours (
     id integer NOT NULL,
     day text NOT NULL,
-    start time without time zone,
-    "end" time without time zone
+    start time with time zone,
+    "end" time with time zone
 );
+
 
 
 ALTER TABLE public.business_hours OWNER TO postgres;
@@ -50,9 +51,9 @@ ALTER TABLE ONLY public.business_hours
 --
 
 INSERT INTO public.business_hours VALUES (1, 'Sunday', NULL, NULL);
-INSERT INTO public.business_hours VALUES (2, 'Monday', '08:00:00', '16:00:00');
-INSERT INTO public.business_hours VALUES (3, 'Tuesday', '08:00:00', '16:00:00');
-INSERT INTO public.business_hours VALUES (6, 'Friday', '08:00:00', '16:00:00');
-INSERT INTO public.business_hours VALUES (5, 'Thursday', '08:00:00', '16:00:00');
-INSERT INTO public.business_hours VALUES (4, 'Wednesday', '08:00:00', '16:00:00');
-INSERT INTO public.business_hours VALUES (7, 'Saturday', '09:00:00', '16:00:00');
+INSERT INTO public.business_hours VALUES (2, 'Monday', '08:00:00-08', '16:00:00-08');
+INSERT INTO public.business_hours VALUES (3, 'Tuesday', '08:00:00-08', '16:00:00-08');
+INSERT INTO public.business_hours VALUES (6, 'Friday', '08:00:00-08', '16:00:00-08');
+INSERT INTO public.business_hours VALUES (5, 'Thursday', '08:00:00-08', '16:00:00-08');
+INSERT INTO public.business_hours VALUES (4, 'Wednesday', '08:00:00-08', '16:00:00-08');
+INSERT INTO public.business_hours VALUES (7, 'Saturday', '09:00:00-08', '16:00:00-08');

--- a/api/business_status_view.sql
+++ b/api/business_status_view.sql
@@ -1,0 +1,21 @@
+CREATE VIEW public.business_status AS
+ SELECT dateinfo."current_date",
+    bh.day AS today,
+        CASE
+            WHEN ((bc.* IS NULL) AND (dateinfo."time" > bh.start) AND (dateinfo."time" < bh."end")) THEN 'open'::text
+            ELSE 'closed'::text
+        END AS status,
+    bc.description AS closed_reason,
+    bh.start AS opens,
+    bh."end" AS closes
+   FROM ((( SELECT btrim(to_char(timezone('pst'::text, now()), 'Day'::text)) AS weekday,
+            timezone('pst'::text, CURRENT_TIME) AS "time",
+            timezone('pst'::text, now()) AS "current_date") dateinfo
+     JOIN public.business_hours bh ON ((bh.day = dateinfo.weekday)))
+     LEFT JOIN public.business_closures bc ON (((dateinfo."current_date" > bc.start_date) AND (dateinfo."current_date" < (
+        CASE
+            WHEN (bc.end_date IS NULL) THEN bc.start_date
+            ELSE bc.end_date
+        END + '1 day'::interval)))))
+  WHERE (dateinfo.weekday = bh.day);
+

--- a/src/components/location/locationStyles.jsx
+++ b/src/components/location/locationStyles.jsx
@@ -69,6 +69,24 @@ export const OpenOrClosed = styled.div`
     }
 `
 
+export const BusinessClosures = styled.div`
+    margin-top: 20px;
+    font-size: 1.8rem;
+    line-height: 1rem;    
+    color: #fff;
+    width: 100%;
+    position: relative;
+    bottom: 20px;
+    left: 0;
+    text-align: center;
+    font-family: 'Montserrat', sans-serif;
+    
+    @media screen and (max-width: 900px) {
+        position: relative;
+    }
+`
+
+
 export const LocationInformation = styled.div`
     color: #fff;
     width: 80%;

--- a/src/helperFunctions/format.js
+++ b/src/helperFunctions/format.js
@@ -1,0 +1,11 @@
+
+export const formatDate = (timestamp) => {
+
+    const date = new Date(timestamp);
+    
+    const formattedDate = date.toLocaleDateString('en-GB', {
+    day: 'numeric', month: 'long'
+    }).replace(/ /g, ' ');
+
+    return formattedDate
+}


### PR DESCRIPTION
- upcoming business closures displayed from relevant database records
- if current date/time falls within a business closure the API reports the business is closed even if normally open that weekday/time
- updated table schemas for using time zone ( PST / -08 ) 
- uses PST time zone so local browser time is not used for business logic
- closed/open status not displayed on page until status is determined from the API response
- some basic testing has been done to ensure API and rendering is done correctly, further styling and edge case testing would be good before deploying if you have time!
- added a date formatter helper function, accidently staged it along with the styled component so didn't get proper commit comment 👎 